### PR TITLE
Upgrade jinja2 package

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ alabaster==0.7.16
 Babel==2.14.0
 docutils==0.20.1
 imagesize==1.4.1
-Jinja2==3.1.5
+Jinja2==3.1.6
 packaging==21.3
 Pygments==2.17.2
 requests==2.32.2


### PR DESCRIPTION
This is to resolve a reported security vulnerability (CVE-2025-27516) with the jinja2 package affecting versions prior to 3.1.6